### PR TITLE
[CI] Add Docker Hub login step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
* Add a new step to log in to Docker Hub before building and pushing the image
  - Use the `docker/login-action@v2` action
  - Provide the Docker Hub username and password using GitHub secrets

This step ensures that the workflow can authenticate with Docker Hub before attempting to push the built image, which is necessary for the build-and-push job to succeed.